### PR TITLE
feat: ci builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: goreleaser
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]  
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,11 @@
+version: 2
+builds:
+  - id: "accesskeyextractor"
+    binary: accesskeyextractor
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64


### PR DESCRIPTION
When a release (with a tag respecting semantic versioning rules) is created, this builds to amd64 and arm64 for macOS, linux and windows.

nex-go apparently fails to build to 386, might be smth to look into.